### PR TITLE
chore: make API base URL env-configurable for prod deploy

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -1,5 +1,4 @@
-// const BASE_URL = 'https://stacks-api-iota.vercel.app'
-const BASE_URL = 'http://localhost:3001'
+const BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001'
 
 export const getUserRole = async (email, token) => {
     const res = await fetch(`${BASE_URL}/api/v1/users/me`, {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Read backend BASE_URL from REACT_APP_API_URL with a localhost fallback so production (Vercel) hits the deployed API while local dev still works. Add vercel.json SPA rewrite so react-router deep links survive refresh.

# Pull Request

## Description

## Related Issues

## Screenshots (if applicable)
## Changes Made

## Testing

## Checklist
- [ ] The code follows the project's coding standards.
- [ ] Unit tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The code compiles without errors.
- [ ] The changes have been tested locally and pass all relevant tests.
- [ ] All new and existing tests pass.
- [ ] The pull request has been reviewed by at least one other contributor.
## Reviewer Instructions

## Deployment Notes

## Additional Information
