### PR TITLE
Feat/swipers for every genre

### DIFF
--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -1,5 +1,5 @@
-const BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001'
-// const BASE_URL = 'http://localhost:3001'
+// const BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001'
+const BASE_URL = 'http://localhost:3001'
 
 export const getUserRole = async (email, token) => {
     const res = await fetch(`${BASE_URL}/api/v1/users/me`, {
@@ -33,6 +33,15 @@ export const getRecords = async (token) => {
         console.error('Failed to fetch records.', error.message)
         throw error
     }
+}
+
+export const getRecordById = async (id, token) => {
+    const res = await fetch(`${BASE_URL}/albums/${id}`, {
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
+    })
+    if (!res.ok) return null                      // backend sends 400 when missing
+    const data = await res.json()                 // backend sends an ARRAY
+    return Array.isArray(data) ? (data[0] ?? null) : data
 }
 
 export const getGenres = async (token) => {

--- a/src/Components/APICalls.js
+++ b/src/Components/APICalls.js
@@ -1,4 +1,5 @@
 const BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001'
+// const BASE_URL = 'http://localhost:3001'
 
 export const getUserRole = async (email, token) => {
     const res = await fetch(`${BASE_URL}/api/v1/users/me`, {

--- a/src/Components/RecordPage.js
+++ b/src/Components/RecordPage.js
@@ -1,12 +1,12 @@
 import MyStackContext from '../Context/MyStack'
 import { useParams, useNavigate } from 'react-router-dom';
 import '../CSS/RecordPage.css';
-import { useContext } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import AuthAlbumContext from '../Context/AuthAlbumContext';
 import { useAuthorization } from '../Context/AuthorizationContext';
 import { PERMISSIONS } from '../utils/permissions';
 import { getYouTubeVideoID } from '../utils/validation';
-import { deleteAlbum } from './APICalls';
+import { deleteAlbum, getRecordById } from './APICalls';
 
 const RecordPage = () => {
     const { id } = useParams();
@@ -14,8 +14,28 @@ const RecordPage = () => {
     const { myStack, setMyStack } = useContext(MyStackContext)
     const { albums, setAlbums, authCode } = useContext(AuthAlbumContext)
     const { checkAction } = useAuthorization()
-    const allRecords = [...albums, ...myStack]
-    const record = allRecords.find(record => record.id === id);
+
+    // Prefer the in-memory list, but fall back to a by-id fetch so deep links and
+    // hard reloads (where `albums` hasn't loaded yet) still resolve the record.
+    // Re-runs on id/context change since the route reuses this component instance.
+    const cached = [...albums, ...myStack].find(r => r.id === id) || null
+    const [record, setRecord] = useState(cached)
+    const [loading, setLoading] = useState(!cached)
+
+    useEffect(() => {
+        if (cached) { setRecord(cached); setLoading(false); return }
+        let active = true
+        setRecord(null)
+        setLoading(true)
+        getRecordById(id, authCode)
+            .then(r => { if (active) { setRecord(r); setLoading(false) } })
+            .catch(() => { if (active) setLoading(false) })
+        return () => { active = false }
+    }, [id, cached, authCode])
+
+    if (loading) {
+        return <p>Loading…</p>;
+    }
 
     if (!record) {
         return <p>Record not found.</p>;
@@ -98,11 +118,11 @@ const RecordPage = () => {
                     <h2>{artist}</h2>
                     <p><strong>Release Date:</strong> {releaseDate}</p>
                     <p><strong>Genre:</strong> {genre}</p>
-                    <p><strong>Band Members:</strong> {bandMembers.join(', ')}</p>
+                    <p><strong>Band Members:</strong> {Array.isArray(bandMembers) ? bandMembers.join(', ') : (bandMembers || 'N/A')}</p>
                     <p><strong>Label:</strong> {label}</p>
                     <p><strong>Band Status:</strong> {isBandTogether ? 'Together' : 'Disbanded'}</p>
                     <p><strong>Rolling Stone Review:</strong> {rollingStoneReview}</p>
-                    <p><strong>Albums Sold:</strong> {albumsSold.toLocaleString()}</p>
+                    <p><strong>Albums Sold:</strong> {Number(albumsSold || 0).toLocaleString()}</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# Frontend changes — cron-job album support

Branch: `feat/swipers-for-every-genre`

Summary of the last two commits, which make the frontend resilient to albums that
appear in the database passively (inserted by the daily Vercel/Haiku cron job that
enriches the Rolling Stone Top 500 library), rather than only via a manual UI POST.

---

## `e405775` — fix: reshaped the getter for albums for cron job

**File:** `src/Components/APICalls.js`

- **Added `getRecordById(id, token)`** — a single-album fetch helper for `GET /albums/:id`.
  It normalizes two quirks of the existing backend endpoint:
  - The endpoint returns an **array**, not an object → returns `data[0]` (`?? null`).
  - A missing record responds with **HTTP 400** (not 404) → treats `!res.ok` as
    "not found" and returns `null` instead of throwing.

  ```js
  export const getRecordById = async (id, token) => {
      const res = await fetch(`${BASE_URL}/albums/${id}`, {
          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
      })
      if (!res.ok) return null                      // backend sends 400 when missing
      const data = await res.json()                 // backend sends an ARRAY
      return Array.isArray(data) ? (data[0] ?? null) : data
  }
  ```



---

## `4af71b6` — feat: refactored RecordPage to be responsive to passive cron job album adds

**File:** `src/Components/RecordPage.js`

### 1. By-id fetch fallback for the detail page
Previously the record was derived only from in-memory context
(`[...albums, ...myStack].find(...)`). On a deep link or hard reload of `/:id`, that
list hasn't loaded yet, so the page flashed **"Record not found."**

Now the component prefers the cached record but falls back to `getRecordById`, with a
`Loading…` state in between. The resolution runs in a `useEffect` keyed on
`id`/`cached`/`authCode`, so it also stays correct when navigating between albums
(React Router reuses the component instance when only the `:id` param changes) and
once `albums` finishes loading in context.

```js
const cached = [...albums, ...myStack].find(r => r.id === id) || null
const [record, setRecord] = useState(cached)
const [loading, setLoading] = useState(!cached)

useEffect(() => {
    if (cached) { setRecord(cached); setLoading(false); return }
    let active = true
    setRecord(null)
    setLoading(true)
    getRecordById(id, authCode)
        .then(r => { if (active) { setRecord(r); setLoading(false) } })
        .catch(() => { if (active) setLoading(false) })
    return () => { active = false }
}, [id, cached, authCode])

if (loading) {
    return <p>Loading…</p>;
}
```

- New imports: `useState`, `useEffect` from `react`; `getRecordById` from `./APICalls`.

### 2. Null-safe rendering of scraped fields
Wikipedia-scraped data can write `null` (not `undefined`) for some fields, and JS
default parameters only fill in for `undefined`. Two renders were hardened so a
`null` value no longer crashes the detail page:

| Field | Before | After |
|-------|--------|-------|
| Band Members | `{bandMembers.join(', ')}` | `{Array.isArray(bandMembers) ? bandMembers.join(', ') : (bandMembers || 'N/A')}` |
| Albums Sold | `{albumsSold.toLocaleString()}` | `{Number(albumsSold || 0).toLocaleString()}` |

---

## Net effect
- New cron-inserted albums display with **no further frontend changes**: the landing
  page already renders genre rows dynamically, and the full album list is loaded into
  context on startup.
- Detail pages for those albums now load reliably via deep link / reload and tolerate
  missing or `null` scraped fields.

### Follow-ups (not code)
- Restore the env-driven `BASE_URL` before deploy.
- Have the cron write exact camelCase keys (`albumName`, `imgURL`, `youTubeAlbumURL`,
  `bandMembers` as `string[]`, `albumsSold` as number, …) and prefer omitting keys
  over writing `null`.
- Keep `genre` a single, consistently-cased string — the server's `by-genre` grouping
  keys on it, so casing variants produce separate one-album rows.

