### PR TITLE
Feat/tweak sorting

### DIFF
--- a/src/CSS/LandingPage.css
+++ b/src/CSS/LandingPage.css
@@ -2,8 +2,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    position:relative;
-    z-index:1;
+    position: relative;
+    z-index: 1;
     padding-top: 2.25rem;
     min-height: 100vh;
     width: 100vw;
@@ -13,26 +13,36 @@
     margin-bottom: 1.25rem;
     display: flex;
     justify-content: space-between;
+    align-items: center;
     gap: 0.625rem;
-    width: 90vw;
+    width: 80vw;
 }
 
 .filters input,
 .filters select {
+    box-sizing: border-box;
     padding: 0.625rem;
     font-size: 1rem;
     border-radius: 0.5rem;
-    box-shadow: 0 0 1em 0 rgba(0, 0, 0, 0.2);
+    height: 2.75rem;
+    width: 20rem;
+    background-color: black;
+    color: white;
+    border: 2px solid #600ccf;
 }
 
 .loading-message {
-    color:white;
+    color: white;
 }
+
 label {
-    color:white;
+    color: white;
 }
-input {
-    width: 15rem;
+
+input::placeholder {
+    color: #fff;
+    opacity:1;
+
 }
 
 select {
@@ -45,12 +55,43 @@ select {
     margin-bottom: 1.5rem;
 }
 
+.genre-row-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding-right: 0.5rem;
+}
+
 .genre-heading {
     color: #fff;
     margin: 0 0 0.25rem;
     padding-left: 0.5rem;
     font-size: 1.5rem;
     text-transform: capitalize;
+}
+
+/* Shared look for the genre-order and per-row sort toggles */
+.genre-order-toggle,
+.row-sort-toggle {
+    background: none;
+    border: #600ccf 2px solid;
+    border-radius: 0.5rem;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1rem;
+    padding: 0.4rem 0.75rem;
+    white-space: nowrap;
+}
+
+.genre-order-toggle:hover,
+.row-sort-toggle:hover {
+    background-color: #600ccf;
+}
+
+.row-sort-toggle {
+    font-size: 0.875rem;
+    padding: 0.25rem 0.6rem;
 }
 
 

--- a/src/CSS/MyStackAlbum.css
+++ b/src/CSS/MyStackAlbum.css
@@ -1,0 +1,55 @@
+.my-stack-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    cursor: pointer;
+    width: 100%;
+    overflow: hidden;
+    border-radius: 0.5rem;
+}
+
+.my-stack-card img {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: 0.5rem;
+    display: block;
+}
+
+.my-stack-card-info {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(7, 7, 7, 0.708);
+    color: #fff;
+    text-align: center;
+    padding: 0.625rem;
+    box-sizing: border-box;
+    border-radius: 0.5rem;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.my-stack-card:hover .my-stack-card-info {
+    display: flex;
+    opacity: 1;
+}
+
+.my-stack-card-info h3,
+.my-stack-card-info h4,
+.my-stack-card-info p {
+    margin: 0;
+}
+
+.my-stack-card-info .delete-button {
+    margin-top: 0.5rem;
+}

--- a/src/CSS/MyStackPage.css
+++ b/src/CSS/MyStackPage.css
@@ -9,12 +9,20 @@
     justify-items: center;
     color: white;
     text-decoration: underline;
+    z-index: 1;
 }
+
+.my-stack-container {
+    width: 100%;
+    padding: 0 2rem 2rem;
+    box-sizing: border-box;
+}
+
 .my-stack-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1.5rem;
+    width: 100%;
 }
 
 
@@ -29,6 +37,13 @@
 
 .back-to-main {
     margin-top: 2rem;
+}
+
+/* Sit the "pick out more" button on its own row, centered across all columns */
+.my-stack-wrapper .main-gallery-link {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: center;
 }
 
 p {

--- a/src/Components/GenreRow.js
+++ b/src/Components/GenreRow.js
@@ -1,6 +1,6 @@
 import AlbumCarousel from './AlbumCarousel'
 import { getAlbumsByGenreName } from './APICalls'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 
 // One genre's carousel. Albums are fetched lazily the first time the row scrolls
 // near the viewport, so the landing page renders cheap shells up front instead of
@@ -12,6 +12,16 @@ function GenreRow({ genre, authCode, addToStack }) {
     const [loaded, setLoaded] = useState(false)
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState('')
+    const [rowOrder, setRowOrder] = useState('asc')
+
+    // Sort a copy by album name so the toggle is instant (no refetch) and the
+    // original `albums` state stays intact for delete-by-id.
+    const sortedAlbums = useMemo(() => {
+        const sorted = [...albums].sort((a, b) =>
+            (a.albumName ?? '').localeCompare(b.albumName ?? '')
+        )
+        return rowOrder === 'desc' ? sorted.reverse() : sorted
+    }, [albums, rowOrder])
 
     // Flip `visible` the first time the row nears the viewport, then stop
     // observing — we only need the one-shot trigger to kick off the fetch.
@@ -61,7 +71,19 @@ function GenreRow({ genre, authCode, addToStack }) {
 
     return (
         <section ref={sectionRef} className="genre-row">
-            <h2 className="genre-heading">{genre}</h2>
+            <div className="genre-row-header">
+                <h2 className="genre-heading">{genre}</h2>
+                {loaded && albums.length > 1 && (
+                    <button
+                        type="button"
+                        className="row-sort-toggle"
+                        onClick={() => setRowOrder(o => (o === 'asc' ? 'desc' : 'asc'))}
+                        aria-label={`Sort ${genre} albums`}
+                    >
+                        {rowOrder === 'asc' ? 'A–Z' : 'Z–A'}
+                    </button>
+                )}
+            </div>
             {error && <p className="error-message">Error: {error}</p>}
             {!loaded && (
                 <div className="genre-row-placeholder">
@@ -70,7 +92,7 @@ function GenreRow({ genre, authCode, addToStack }) {
             )}
             {loaded && albums.length > 0 && (
                 <AlbumCarousel
-                    albums={albums}
+                    albums={sortedAlbums}
                     addToStack={addToStack}
                     onAlbumDeleted={handleAlbumDeleted}
                 />

--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -14,7 +14,8 @@ import { useAuth0 } from "@auth0/auth0-react";
 // requires the backend ALBUM_SORTABLE whitelist to include it.
 const SORT_OPTIONS = [
     { value: '', label: 'Sort by…', sortBy: '', order: '' },
-    { value: 'name', label: 'Album name (A–Z)', sortBy: 'albumName', order: 'asc' },
+    { value: 'name-asc', label: 'Album name (A–Z)', sortBy: 'albumName', order: 'asc' },
+    { value: 'name-desc', label: 'Album name (Z–A)', sortBy: 'albumName', order: 'desc' },
     { value: 'sales', label: 'Best selling', sortBy: 'albumsSold', order: 'desc' },
     { value: 'rating', label: 'Highest rated', sortBy: 'rollingStoneReview', order: 'desc' },
 ]
@@ -31,6 +32,7 @@ function LandingPage() {
     const [searchError, setSearchError] = useState('')
     const [selectedGenre, setSelectedGenre] = useState('')
     const [selectedSort, setSelectedSort] = useState('')
+    const [genreOrder, setGenreOrder] = useState('asc')
     const [browseResults, setBrowseResults] = useState([])
     const [browseLoading, setBrowseLoading] = useState(false)
     const [browseError, setBrowseError] = useState('')
@@ -45,11 +47,15 @@ function LandingPage() {
     const isBrowsing = !isSearching && (selectedGenre !== '' || selectedSort !== '')
 
     // Canonical genres drive the carousels; every genre (incl. user-contributed)
-    // populates the filter dropdown.
-    const canonicalGenres = useMemo(
-        () => genres.filter(g => g.isCanonical).map(g => g.name),
-        [genres]
-    )
+    // populates the filter dropdown. The carousels sort alphabetically and flip
+    // with the genre-order toggle; the dropdown order is left as the API returns.
+    const canonicalGenres = useMemo(() => {
+        const names = genres
+            .filter(g => g.isCanonical)
+            .map(g => g.name)
+            .sort((a, b) => a.localeCompare(b))
+        return genreOrder === 'desc' ? names.reverse() : names
+    }, [genres, genreOrder])
     const allGenreNames = useMemo(() => genres.map(g => g.name), [genres])
 
     // Fetch only the lightweight list of genres up front; each genre's albums
@@ -178,6 +184,14 @@ function LandingPage() {
                         <option key={o.value} value={o.value}>{o.label}</option>
                     ))}
                 </select>
+                <button
+                    type="button"
+                    className="genre-order-toggle"
+                    onClick={() => setGenreOrder(o => (o === 'asc' ? 'desc' : 'asc'))}
+                    aria-label="Flip genre order"
+                >
+                    {genreOrder === 'asc' ? 'Genres A–Z' : 'Genres Z–A'}
+                </button>
             </div>
 
             {isSearching && (

--- a/src/Components/MyStackAlbum.js
+++ b/src/Components/MyStackAlbum.js
@@ -14,9 +14,9 @@ const navigate = useNavigate()
     }
 
     return (
-        <div className="album-cards" onClick={handleClick}>
+        <div className="my-stack-card" onClick={handleClick}>
         <img src={album.imgURL} alt={`${album.title} cover`} />
-        <div className="album-info">
+        <div className="my-stack-card-info">
             <h3>{album.artist}</h3>
             <h4>{album.albumName}</h4>
             <p>{album.genre}</p>

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ root.render(
         audience: audience
       }}
       scope="openid email username"
+      cacheLocation="localstorage"
+      useRefreshTokens={true}
       >
 
       <App />


### PR DESCRIPTION
# Branch: `feat/tweak-sorting`

Improvements to the My Stack layout and the landing-page sorting/filtering, plus
a fix for the disappearing hamburger menu.

## Summary

| Area | Change |
| --- | --- |
| My Stack page | Album cards now lay out as an even 5-column grid |
| Sorting | Alphabetical sort works both directions (A–Z and Z–A) |
| Genre display | Toggle to flip the order of the genre carousels |
| Genre rows | Each row can be sorted A–Z / Z–A by album name |
| Auth | Hamburger menu no longer disappears on reload |

---

## 1. My Stack: 5-column grid

**Files:** `src/Components/MyStackAlbum.js`, `src/CSS/MyStackAlbum.css`,
`src/CSS/MyStackPage.css`

- `.my-stack-wrapper` is now a CSS grid (`repeat(5, 1fr)`), collapsing to 2
  columns under 64rem and 1 column under 48rem.
- The "Go Pick Out Some More!" button spans all columns on its own centered row.
- **Root cause fixed:** the My Stack cards used the class names `.album-cards` /
  `.album-info`, which are also defined globally in `Record.css` (fixed 24rem
  squares with the info hidden until hover). Because Create React App injects all
  imported CSS globally, the My Stack cards were being styled by `Record.css`.
  The card markup was renamed to `.my-stack-card` / `.my-stack-card-info` and
  given its own styles in `MyStackAlbum.css` (previously empty) to decouple it.
- The card info (artist / album / genre / delete button) renders as a hover
  overlay over the cover, matching the Record cards.

## 2. Two-way alphabetical sort

**File:** `src/Components/LandingPage.js`

- `SORT_OPTIONS` gained an "Album name (Z–A)" entry alongside "(A–Z)". Sorting is
  server-side via the existing `order` query param on `getAlbums`, so this was
  purely additive.

## 3. Flip genre carousel order

**Files:** `src/Components/LandingPage.js`, `src/CSS/LandingPage.css`

- New `genreOrder` state with a "Genres A–Z / Z–A" toggle button in the filter
  bar.
- `canonicalGenres` now sorts alphabetically and reverses on toggle. Scope is
  **carousel rows only** — the genre filter dropdown order is unchanged.

## 4. Sort an individual GenreRow

**Files:** `src/Components/GenreRow.js`, `src/CSS/LandingPage.css`

- Each row (with ≥2 albums) shows an "A–Z / Z–A" button that sorts that row's
  albums by album name.
- Sorting is **client-side** on a copy of the already-loaded `albums` state
  (instant, no refetch; the original array is preserved so delete-by-id still
  works).

## 5. Filter-bar styling fix

**File:** `src/CSS/LandingPage.css`

- Search input and dropdowns now share `box-sizing: border-box` + a fixed height,
  so the search bar no longer renders taller than the dropdowns.
- `.filters` uses `align-items: center` so the toggle button lines up with the
  controls.

## 6. Hamburger menu persistence (auth fix)

**File:** `src/index.js`

- The hamburger is gated on Auth0's `isAuthenticated`. With the default
  in-memory token cache, a full page reload wiped the session and the button
  disappeared until re-login.
- Added `cacheLocation="localstorage"` and `useRefreshTokens={true}` to the
  `Auth0Provider` so the session survives reloads.
- **Note:** requires the Refresh Token grant enabled on the Auth0 application;
  `localstorage` persistence carries the usual minor XSS tradeoff vs. in-memory.

---

## Commits

- `feat: adjusted MyStack to feature grid`
- `feat: made component sortable alphabetically (asc/desc)`
- `ref: tweaked LandingPage to accommodate more complex sorting and filtering`
- `feat: tweaked styling of inputs and buttons`
- `feat: fixed auth bug in hamburger by adding local storage for token`
